### PR TITLE
fix: add css variables to support dark theme

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -101,7 +101,7 @@
       margin: 0;
       padding: 50px 30px;
       border-radius: 20px;
-      background-color: whitesmoke;
+      background-color: var(--pannel-bg);
    }
    .instrucao {
       font-size: 2em;

--- a/src/app.css
+++ b/src/app.css
@@ -1,11 +1,34 @@
+@media (prefers-color-scheme: dark) {
+  :root {
+    --main-bg: #242424;
+    --pannel-bg: #363636;
+    --memory-bg: #454545;
+    --bit-button-color: #213547;
+    --text-color: rgba(255, 255, 255, 0.87);
+    --link-color: #646cff;
+    --link-hover-color: #535bf2;
+  }
+}
+
+@media (prefers-color-scheme: light) {
+  :root {
+    --main-bg: #fff;
+    --pannel-bg: whitesmoke;
+    --memory-bg: #f8f8ff;
+    --bit-button-color: #213547;
+    --text-color: #213547;
+    --link-color: #646cff;
+    --link-hover-color: #747bff;
+  }
+}
+
 :root {
   font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;
   font-weight: 400;
-
   color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
+  color: var(--text-color);
+  background-color: var(--main-bg);
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;
@@ -16,11 +39,11 @@
 
 a {
   font-weight: 500;
-  color: #646cff;
+  color: var(--link-color);
   text-decoration: inherit;
 }
 a:hover {
-  color: #535bf2;
+  color: var(--link-hover-color);
 }
 
 body {
@@ -63,17 +86,4 @@ button:hover {
 button:focus,
 button:focus-visible {
   outline: 4px auto -webkit-focus-ring-color;
-}
-
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
 }

--- a/src/lib/Bit.svelte
+++ b/src/lib/Bit.svelte
@@ -28,6 +28,7 @@
    }
 
    button.bit {
+      color: var(--bit-button-color);
       border-radius: 0;
       padding: 10px;
       font-size: 2em;

--- a/src/lib/Memoria.svelte
+++ b/src/lib/Memoria.svelte
@@ -33,7 +33,7 @@
       display: inline-block;
    }
    table.mem {
-      background-color: ghostwhite;
+      background-color: var(--memory-bg);
       font-family: monospace;
       font-size: 1.5em;
       line-height: 1em;


### PR DESCRIPTION
Adicionando suporte a dark theme por meio da definição de CSS Variables para as cores da aplicação.

Houve alterações apenas na parte de estilização (CSS):
- [x] Adicionando CSS Variables para o modo dark e light.
- [x] Alternando entre a definição das variáveis para dark e light.
- [x] Substituindo cores fixas pelas variáveis criadas.

### Antes

Antes das modificações, a aplicação estava dessa maneira para o navegador no dark mode:

![image](https://github.com/user-attachments/assets/3247c178-7228-4ad1-8819-a797826d2e11)

### Depois

Depois das modificações, a aplicação tem o seguinte comportamento:

![image](https://github.com/user-attachments/assets/ba550485-6634-42f2-a06f-37bd8c84dbb7)

Importante ressaltar que o comportamento no light mode continua o mesmo:

![image](https://github.com/user-attachments/assets/a946205b-d7ee-46bd-a558-4c0544d10544)

  